### PR TITLE
Improved comments and bugfixes (SafeConfigParser, division by zero, log.warn)

### DIFF
--- a/BS440.example.ini
+++ b/BS440.example.ini
@@ -5,15 +5,20 @@
 
 
 # Scale properties
-# Model: BS410, BS430, BS440, BS444
 [Scale] 
+# Bluetooth LE MAC address of the scale
 ble_address: aa:bb:cc:11:22:33
+# Device name of the scale
 device_name: 0202B6332211CCBBAA
+# Model of the scale
+# Supported models: BS410, BS430, BS440, BS444
+# BSA45 allegedly supported, but manual adjustments needed / not yet implemented in code
+# (see https://github.com/keptenkurk/BS440/issues/103)
 device_model: BS440
 
 # Program behaviour
-# Loglevel: debug | info | critical | error
 [Program]
+# Loglevel: debug | info | critical | error
 loglevel: debug
 logfile: BS440.log
 # Enable your plugins here, use the comma separated basename from the plugins/

--- a/BS440.example.ini
+++ b/BS440.example.ini
@@ -23,4 +23,4 @@ loglevel: debug
 logfile: BS440.log
 # Enable your plugins here, use the comma separated basename from the plugins/
 # Example:
-# plugins: BS440csv, BS440mail
+# plugins: BS440csv, BS440domoticz, BS440googlle, BS440influxdb, BS440mail, BS440mqtt, BS440runalyzel

--- a/BS440.py
+++ b/BS440.py
@@ -380,7 +380,7 @@ while True:
             handle_command = device.get_handle(Char_command)
             continue_comms = True
         except pygatt.exceptions.NotConnectedError:
-            log.warn('Error getting handles')
+            log.warning('Error getting handles')
             continue_comms = False
 
         log.info('Continue Comms: ' + str(continue_comms))

--- a/BS440.py
+++ b/BS440.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import pygatt.backends
 import logging
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 import time
 import subprocess
 from struct import *
@@ -9,33 +9,64 @@ from binascii import hexlify
 import os
 import sys
 
-
-# Interesting characteristics
+# Relevant characteristics submitted by the scale
+# (Explanation see below)
+Char_person = '00008a82-0000-1000-8000-00805f9b34fb'  # person data
 Char_weight = '00008a21-0000-1000-8000-00805f9b34fb'  # weight data
 Char_body = '00008a22-0000-1000-8000-00805f9b34fb'  # body data
 Char_command = '00008a81-0000-1000-8000-00805f9b34fb'  # command register
-Char_person = '00008a82-0000-1000-8000-00805f9b34fb'  # person data
-         
 
 '''
-The decode functions Read Medisana BS440 Scale hex Indication and 
-decodes scale values from hex data string.
-Each function receives the hex handle and bytevalues and
-return a dictionary with the decoded data
+Information on the functions decodePerson, decodeWeight, decodeBody
+
+The scale submits relevant data by use of Indications.
+Indications are messages conveying the data for certain characteristics.
+Characteristics have a two-byte shortcut for it (the handle) an a 16 byte
+(globally unique) identifier (the UUID).
+
+Relevant characteristics:
+Description Handle      UUID                                  Data
+            (2 byte)    (16 byte, globally unique)
+Person      0x26        00008a82-0000-1000-8000-00805f9b34fb  person, gender, age, size, activity
+Weight      0x1c        00008a21-0000-1000-8000-00805f9b34fb  weight, time, person
+Body        0x1f        00008a22-0000-1000-8000-00805f9b34fb  time, person, kcal, fat, tbw, muscle, bone 
+
+Writing the command 0200 to a handle tells the device that you register to the
+indications of this characteristic. Writing 0000 will stop it.
+
+A data packet of a characteristic (hex data string) will report with a
+handle 1 less than the handle of the characteristic. E.g. writing 0200
+to 0x26 (Person) will report back with the handle 0x25.
+
+The last 30 measurements per person will be stored in the scale and upon
+communication, the history for this user will be dumped. So you will
+receive 30 values like this: 
+handle=0x25, value=0x845302800134b6e0000000000000000000000000
+handle=0x1b, value=0x1d8c1e00fe6e0aa056451100ff020900000000
+handle=0x1e, value=0x6f6e0aa05602440ab8f07ff26bf11ef0000000
+
+To decode the scale values (from hex data strings), three separate functions
+are used. Each function receives the hex handle (e.g. 0x25) and bytevalues,
+and then returns a dictionary with the decoded data. The datastrings are
+interpreted using struct.unpack (see here https://docs.python.org/2/library/struct.html).
 '''
 
 def decodePerson(handle, values):
     '''
     decodePerson
-    handle: 0x25
-    values[0] = 0x84
-    Returns a dict for convenience:
-        valid (True, False)
-        person (1..9)
-        gender (male|female)
-        age (0..255 years)
-        size (0..255 cm)
-        activity (normal|high)
+    Handle: 0x25 (Person)                
+    Value:
+        Byte  Data                         Value/Return   Interpretation pattern
+        0     fixed byte (validity check)  [0x84]         B (integer, lenght 1)
+        1     -pad byte-                                  x (pad byte)
+        2     person                       [1..8]         B ((integer, lenght 1)
+        3     -pad byte-                                  x (pad byte)
+        4     gender (1=male, 2=female)    [1|2]          B (integer, lenght 1)
+        5     age                          [0..255 years] B (integer, lenght 1)
+        6     size                         [0..255 cm]    B (integer, lenght 1)
+        7     -pad byte-                                  x (pad byte)
+        8     activity (0=normal, 3=high)  [0|3]          B (integer, lenght 1)
+        --> Interpretation pattern:                       BxBxBBBxB
     '''
     data = unpack('BxBxBBBxB', bytes(values[0:9]))
     retDict = {}
@@ -53,35 +84,34 @@ def decodePerson(handle, values):
         retDict["activity"] = "normal"
     return retDict
 
-def sanitize_timestamp(timestamp):
-    retTS = 0
-    if timestamp + time_offset < sys.maxsize:
-        retTS = timestamp + time_offset
-    else:
-        retTS = timestamp
-
-    if timestamp >= sys.maxsize:
-        retTS = 0
-
-    return retTS
-
 
 def decodeWeight(handle, values):
     '''
     decodeWeight
-    Handle: 0x1b
-    Byte[0] = 0x1d
-    Returns:
-        valid (True, False)
-        weight (5,0 .. 180,0 kg)
-        timestamp (unix timestamp date and time of measurement)
-        person (1..9)
-        note: in python 2.7 to force results to be floats,
-        devide by float.
-        '''
+    Handle: 0x1b (Weight)             
+    Value:
+        Byte  Data                         Value/Return       Interpretation pattern
+         0    fixed byte (validity check)  [0x1d]             B (integer, length 1)
+         1    weight                       [5,0..180,0 kg]    H (integer, length 2)                     
+         2    weight                       
+         3    -pad byte-                                      x (pad byte)
+         4    -pad byte-                                      x (pad byte)   
+         5    timestamp                    Unix, date & time  I (integer, length 4)
+         6    timestamp              
+         7    timestamp                                 
+         8    timestamp
+         9    -pad byte-                                      x (pad byte) 
+        10    -pad byte-                                      x (pad byte) 
+        11    -pad byte-                                      x (pad byte) 
+        12    -pad byte-                                      x (pad byte) 
+        13    person                       [1..8]             B (integer, length 1)
+        --> Interpretation pattern:                           BHxxIxxxxB              
+    '''
     data = unpack('<BHxxIxxxxB', bytes(values[0:14]))
     retDict = {}
     retDict["valid"] = (data[0] == 0x1d)
+    # Weight is reported in g. Hence, divide by 100.0
+    # To force results to be floats: devide by float.
     retDict["weight"] = data[1]/100.0
     retDict["timestamp"] = sanitize_timestamp(data[2])
     retDict["person"] = data[3]
@@ -91,18 +121,27 @@ def decodeWeight(handle, values):
 def decodeBody(handle, values):
     '''
     decodeBody
-    Handle: 0x1e
-    Byte[0] = 0x6f
-    Returns:
-        valid (True, False)
-        timestamp (unix timestamp date and time of measurement)
-        person (1..9)
-        kcal = (0..65025 Kcal)
-        fat = (0..100,0 %)  percentage of body fat
-        tbw = (0..100,0 %) percentage of water
-        muscle = (0..100,0 %) percentage of muscle
-        bone = (0..100,0) bone weight
-        note: in python 2.7 to force results to be floats: devide by float.
+    Handle: 0x1e (Body)               
+    Value:
+        Byte  Data                          Value/Return       Interpretation pattern
+         0    fixed byte (validity check)   [0x6f]             B (integer, lenght 1)
+         1    timestamp                     Unix, date & time  I (integer, length 4)
+         2    timestamp              
+         3    timestamp                                 
+         4    timestamp
+         5    person                        [1..8]             B (integer, lenght 1)
+         6    kcal                          [0..65025 Kcal]    H (integer, length 2)
+         7    kcal
+         8    fat (percentage of body fat)  [0..100,0 %]       H (integer, length 2)
+         9    fat (percentage of body fat)
+        10    tbw (percentage of water)     [0..100,0 %]       H (integer, length 2)
+        11    tbw (percentage of water)
+        12    muscle (percentage of muscle) [0..100,0 %]       H (integer, length 2)
+        13    muscle (percentage of muscle)
+        14    bone (bone weight)            [0..100,0 %]       H (integer, length 2)
+        15    bone (bone weight)
+        --> Interpretation pattern:                            BIBBHHHHH
+    Notes: For kcal, fat, tbw, muscle, bone: First nibble = 0xf
     '''
     data = unpack('<BIBHHHHH', bytes(values[0:16]))
     retDict = {}
@@ -110,13 +149,46 @@ def decodeBody(handle, values):
     retDict["timestamp"] = sanitize_timestamp(data[1])
     retDict["person"] = data[2]
     retDict["kcal"] = data[3]
+    # Fat, water, muscle and bone are reported in *10. Hence, divide by 10.0
+    # To force results to be floats: devide by float.
     retDict["fat"] = (0x0fff & data[4])/10.0
     retDict["tbw"] = (0x0fff & data[5])/10.0
     retDict["muscle"] = (0x0fff & data[6])/10.0
     retDict["bone"] = (0x0fff & data[7])/10.0
     return retDict
 
+
+def sanitize_timestamp(timestamp):
+    '''
+    timestamp: timestamp of measurement transmitted by the scale
+
+    On some scales (e.g. BS410 and BS444, maybe others as well), time=0
+    equals 1/1/2010. However, goal is to have unix-timestamps. Thus, the
+    function converts the "scale-timestamp" to unix-timestamp by adding
+    the time-offset (most scales: 1262304000 = 01.01.2010) to the timestamp.
+    '''
+    retTS = 0
+    # Fail-safe: The timestamp will only be sanitized, if it will be
+    # below below the maximum unix timestamp (2147483647). Otherwise the
+    # non-sanitized timestamp will be taken.
+    if timestamp + time_offset < sys.maxsize:
+        retTS = timestamp + time_offset
+    else:
+        retTS = timestamp
+    # If already the non-sanitized timestamp is above the maximum unix timestamp
+    # 0 will be taken instead.
+    if timestamp >= sys.maxsize:
+        retTS = 0
+    return retTS
+
+
 def appendBmi(size, weightdata):
+    '''
+    appendBMI: Calculates the BMI (not calculated/ provided by the scale itself).
+
+    size: size of the person (fixed), stored in the scale
+    weightdata: list of weights of the previous x measurements
+    '''
     size = size / 100.00
     for element in weightdata:
         element['bmi'] = round(element['weight'] / (size * size), 1)
@@ -125,10 +197,12 @@ def appendBmi(size, weightdata):
 def processIndication(handle, values):
     '''
     Indication handler:
-    Receives indication and stores values into result Dict
-    (see decode functions for Dict definition)
-    handle: byte
-    value: bytearray
+    Receives indication, decodes the information stored in the bytearray, and
+    stores values into result Dict (see decodePerson, decodeWeight and decodeBody
+    functions for Dict definition).
+     
+    handle: byte (e.g. 0x26 for person, 0x1c for weight or 0x1f for body)
+    values: bytearray (e.g. 0x845302800134b6e0000000000000000000000000)
     '''
     if handle == handle_person:
         result = decodePerson(handle, values)
@@ -156,23 +230,33 @@ def processIndication(handle, values):
 
 
 def wait_for_device(devname):
+    '''
+    Reset adapter in case of pygatt exception error
+    '''
     found = False
     while not found:
         try:
-            # wait for scale to wake up and connect to it
+            # wait for scale to wake up and connect to it under the scale name (devname)
             found = adapter.filtered_scan(devname)
         except pygatt.exceptions.BLEError:
-            # reset adapter when (see issue #33)
+            # reset adapter when (see issue /keptenkurk/BS440/issues/33)
             adapter.reset()
     return
 
 
 def connect_device(address):
+    '''
+    Connects to the scale defined by the MAC address (address).
+    If successful, returns the instance of the BLEDevice. Otherwise NULL.
+    '''
     device_connected = False
     tries = 3
     device = None
     while not device_connected and tries > 0:
         try:
+            # address: MAC address of the scale
+            # 8: ?
+            # addresstype: ?
             device = adapter.connect(address, 8, addresstype)
             device_connected = True
         except pygatt.exceptions.NotConnectedError:
@@ -181,6 +265,9 @@ def connect_device(address):
 
 
 def init_ble_mode():
+    '''
+    Activates Bluetooth LE
+    '''
     p = subprocess.Popen("sudo btmgmt le on", stdout=subprocess.PIPE,
                          shell=True)
     (output, err) = p.communicate()
@@ -191,10 +278,12 @@ def init_ble_mode():
         log.info(err)
         return False
 
+
 '''
 Main program loop
 '''
-config = SafeConfigParser()
+# Read .ini file and set plugins-folder
+config = ConfigParser()
 config.read('BS440.ini')
 path = "plugins/"
 plugins = {}
@@ -218,7 +307,6 @@ ch.setFormatter(formatter)
 log.addHandler(ch)
 
 # Load configured plugins
-
 if config.has_option('Program', 'plugins'):
     config_plugins = config.get('Program', 'plugins').split(',')
     config_plugins = [plugin.strip(' ') for plugin in config_plugins]
@@ -234,10 +322,12 @@ else:
     log.info('No plugins configured.')
 sys.path.pop(0)
 
+# Load scale information from .ini-file
 ble_address = config.get('Scale', 'ble_address')
 device_name = config.get('Scale', 'device_name')
 device_model = config.get('Scale', 'device_model')
 
+# Set BLE address type and time offset, depending on scale model
 if device_model == 'BS410':
     addresstype = pygatt.BLEAddressType.public
     # On BS410 time=0 equals 1/1/2010. 
@@ -251,7 +341,8 @@ elif device_model == 'BS444':
 else:
     addresstype = pygatt.BLEAddressType.random
     time_offset = 0
-    
+
+
 '''
 Start BLE comms and run that forever
 '''
@@ -265,15 +356,17 @@ adapter.start()
 while True:
     wait_for_device(device_name)
     device = connect_device(ble_address)
+    # If the device was connected successfully (the variable "device" has
+    # been defined an contains the instance of the BLEDevice) the main loop runs
     if device:
         persondata = []
         weightdata = []
         bodydata = []
-        
         try:
-            handle_body = device.get_handle(Char_body)
+            # Get the two-byte shortcut (the handle)
             handle_person = device.get_handle(Char_person)
             handle_weight = device.get_handle(Char_weight)
+            handle_body = device.get_handle(Char_body)
             handle_command = device.get_handle(Char_command)
             continue_comms = True
         except pygatt.exceptions.NotConnectedError:
@@ -304,7 +397,8 @@ while True:
         Send the unix timestamp in little endian order preceded by 02 as
         bytearray to handle 0x23. This will resync the scale's RTC.
         While waiting for a response notification, which will never
-        arrive, the scale will emit 30 Indications on 0x1b and 0x1e each.
+        arrive, the scale will emit 30 Indications on 0x1b (weight)
+        and 0x1e (body) each.
         '''
         if continue_comms:
             timestamp = bytearray(pack('<I', int(time.time() - time_offset)))

--- a/BS440.py
+++ b/BS440.py
@@ -191,6 +191,13 @@ def appendBmi(size, weightdata):
     '''
     size = size / 100.00
     for element in weightdata:
+        '''
+        Some scales (e.g. BS 444) identify the max. 8 users via a "weight approximation".
+        If a new (or guest) user stands on the scale, the scale is not able to identify the user.
+        As a result, no size for the user is stored in the scale, and thus not transmitted
+        to the script. In these situations, the script stopped (division by zero). The following
+        check aims at solving this problem (https://github.com/keptenkurk/BS440/issues/102)
+        '''
         if size != 0:
             element['bmi'] = round(element['weight'] / (size * size), 1)
         else:

--- a/BS440.py
+++ b/BS440.py
@@ -110,7 +110,7 @@ def decodeWeight(handle, values):
     data = unpack('<BHxxIxxxxB', bytes(values[0:14]))
     retDict = {}
     retDict["valid"] = (data[0] == 0x1d)
-    # Weight is reported in g. Hence, divide by 100.0
+    # Weight is reported in 10g. Hence, divide by 100.0
     # To force results to be floats: devide by float.
     retDict["weight"] = data[1]/100.0
     retDict["timestamp"] = sanitize_timestamp(data[2])

--- a/BS440.py
+++ b/BS440.py
@@ -198,10 +198,10 @@ def appendBmi(size, weightdata):
         to the script. In these situations, the script stopped (division by zero). The following
         check aims at solving this problem (https://github.com/keptenkurk/BS440/issues/102)
         '''
-        if size != 0:
-            element['bmi'] = round(element['weight'] / (size * size), 1)
-        else:
+        if size == 0:
             element['bmi'] = 0
+        else:
+            element['bmi'] = round(element['weight'] / (size * size), 1)
 
 
 def processIndication(handle, values):

--- a/BS440.py
+++ b/BS440.py
@@ -191,7 +191,10 @@ def appendBmi(size, weightdata):
     '''
     size = size / 100.00
     for element in weightdata:
-        element['bmi'] = round(element['weight'] / (size * size), 1)
+        if size != 0:
+            element['bmi'] = round(element['weight'] / (size * size), 1)
+        else:
+            element['bmi'] = 0
 
 
 def processIndication(handle, values):

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-# BS440  v2.0.0
-Python code to talk to Medisana BS440 bluetooth enabled bathroom scale
-User managementboy reports succes with the Medisana BS444 too.
+# BS440
+Python code to talk to Medisana BS410, BS430, BS440 and BS444 bluetooth enabled bathroom scale.
 
-# Blog info
+# Full project description:
 https://keptenkurk.wordpress.com/2016/02/07/connecting-the-medisana-bs440-bluetooth-scale/
 with a full step-by-step installation instruction on
 https://keptenkurk.wordpress.com/2017/03/05/connecting-the-medisana-bs440-bluetooth-scale-epilogue/

--- a/README.md
+++ b/README.md
@@ -1,48 +1,50 @@
-# BS440
-Python code to talk to Medisana BS410, BS430, BS440 and BS444 bluetooth enabled bathroom scale.
+# BS440 - Description
+BS440 is a Python code that listens for information from a Medisana BS410/BS430/BS440/BS444
+or compatible bluetooth bathroom scale. When received via Bluetooth LE , it passes the
+information (weight, fat, bone mass, etc) over to all activated plugins for further processing.
 
-# Full project description:
-https://keptenkurk.wordpress.com/2016/02/07/connecting-the-medisana-bs440-bluetooth-scale/
-with a full step-by-step installation instruction on
-https://keptenkurk.wordpress.com/2017/03/05/connecting-the-medisana-bs440-bluetooth-scale-epilogue/
+Currently supported plugins / data processors:
+- MQTT (Home Assistant, openHAB, ioBroker, etc), via Autodiscovery
+- Local .csv
+- Webpage
+- Domoticz
+- Google Fit
+- InfluxDB
+- Runalyze Database
+- E-Mail
+
+# Further reading:
+- Project origin (5 parts): https://keptenkurk.wordpress.com/2016/02/07/connecting-the-medisana-bs440-bluetooth-scale/
+- Full step-by-step installation instruction (partially outdated, see below): https://keptenkurk.wordpress.com/2017/03/05/connecting-the-medisana-bs440-bluetooth-scale-epilogue/
 
 # Prerequisites
-* Installed Pygatt >= 3.0.0 release
-  WARNING: Pygatt 3.1.1 has been reported to work but Pygatt 3.2 fails to show all characteristics (26-1-2018)
-* Installed BLE adapter
-* Installed Bluez
+- Bluetooth LE adapter
+- Bluez
+- Pygatt >= 3.0.0 release
 
 # Tested on:
+**Raspberry Pi 1 B+**
+- **OS:** Raspberry Pi OS 8 (Jessie), 4.4.38+ #938, Thu Dec 15 15:17:54 GMT 2016 armv6l GNU/Linux)
+- **Bluetooth adapter:** USB device found, idVendor=0a5c, idProduct=21e8, USB device strings: Mfr=1, Product=2, SerialNumber=3, Product: BCM20702A0
+- **Bluez:** 5.44 (from source), 5.23-2+rpi2 (from package manager)
+- **Pygatt:** 3.0.0
 
-* Raspberry Pi B+ running latest Jessie
-	4.4.38+ #938
-	Thu Dec 15 15:17:54 GMT 2016 armv6l GNU/Linux)
-* USB bluetooth adapter:
-	USB device found, idVendor=0a5c, idProduct=21e8
-	USB device strings: Mfr=1, Product=2, SerialNumber=3
-	Product: BCM20702A0
-* Bluez
-  - 5.44 (from source)
-  - 5.23-2+rpi2 (from package manager)
-* Pygatt 3.0.0 installed
+**Raspberry Pi Zero W**
+- **OS:** DietPi V153, 4.9.35+ #1, Tue Jul 4 17:16:26 UTC 2017 armv6l GNU/Linux
+- **Bluetooth adapter:** Onboard
+- **Bluez:** 5.23-2+rpi2 (from package manager)
+- **Pygatt:** 3.0.0
 
+**Raspberry Pi 3 B+**
+- **OS:** Raspberry Pi OS 11 (Bullseye), 5.15.84-v7+ #1613 SMP Thu Jan 5 11:59:48 GMT 2023 armv7
+- **Bluetooth adapter:** Onboard
+- **Bluez:** 5.55
+- **Pygatt:** 4.0.5
 
-* Raspberry Pi Zero W running DietPi V153
-	4.9.35+ #1
-	Tue Jul 4 17:16:26 UTC 2017 armv6l GNU/Linux
-* onboard bluetooth adapter
-* Bluez
-  - 5.23-2+rpi2 (from package manager)
-* Pygatt 3.0.0 installed
-
-# Description
-BS440 listens for information from a Medisana BS410/BS430/BS440/BS444 or compatible bluetooth
-scale. When received, it passes the information to all found data processors found in
-the plugin folder.
-
-# Preferences
-Before using this app, copy `BS440.example.ini` to `BS440.ini` and personalize your settings.
-This file contains the general parameters for communicating with the scale, and which plugins to use.
+# Preferences / Settings
+Before using this app, rename `BS440.example.ini` to `BS440.ini` and personalize your settings.
+This file contains the general parameters for communicating with the scale (Bluetooth LE
+MAC address) and which plugins to use.
 
 # Automatically start
 
@@ -62,27 +64,29 @@ Attention: the systemd service file assumes you copied the contents of this repo
 
 # Plugins
 Currenly these plugins are available:
-* BS440mail: Mail the last 3 stored sets of data to the user
+* BS440mqtt: Send collected data via MQTT to Home Assistant, openHAB, ioBroker for excample
 * BS440csv: Store results locally in csv and graph results through webserver
+* BS440webapp: Publish data on a local webpage
 * BS440domoticz: Store data in virtual sensors of Domoticz home control system
 * BS440google: Store data to Google Fit account
-* BS440runalizel: Store data to local Runalyze database
-* BS440mqtt: Send collected data via MQTT to Home Assistant for excample
 * BS440influxdb: Store collected data into InfluxDB time series database for easy graphing using Grafana
+* BS440runalizel: Store data to local Runalyze database
+* BS440mail: Mail the last 3 stored sets of data to the user
 
 Plugins are found in the plugin folder and named BS440pluginname.py. Each plugin uses
 its private .ini file named BS440pluginname.ini
 To enable a plugin, add it to the `plugins` key in `BS440.ini`.
 
-Directions on how to install prerequisites, configure and use a specific plugin is found
-in the Wiki
+Directions on how to install prerequisites, configure and use a specific plugin is found in the Wiki
 
-## BS440mail
+**BS440mail**
+
 Maintainer: Keptenkurk
 
 Last 3 results are mailed to the user mail adress as configured in BS440mail.ini
 
-## BS440csv
+**BS440csv**
+
 Maintainer: DjZU
 
 Data is added to a local CSV file. Data is presented by running plotBS440.py which
@@ -90,17 +94,20 @@ starts a webserver and serves graphs to the user.
 You can use any web server to serve a static site based on the `csv` files. You can find a
 working example using the Caddy webserver in [dist/caddy/](dist/caddy/).
 
-## BS440mqtt
+**BS440mqtt**
+
 Maintainer: jinnerbichler
 
 Send collected data via MQTT (e.g. to Home Assistant)
 
-## BS440influxdb
+**BS440influxdb**
+
 Maintainer: qistoph
 
 Store collected data in InlfuxDB (e.g. for Grafana)
 
-## Domoticz
+**Domoticz**
+
 Maintainer: Tristan79 - Status: Testing
 
 Configure the Domoticz and user details in BS440domoticz.ini.
@@ -115,17 +122,18 @@ while the other sensors are identified by _idx_ in _BS440domoticz.ini_.
 
 ![domoticz](https://raw.githubusercontent.com/Tristan79/BS440/master/BS440domoticz.png)
 
-## BS440google
+**BS440google**
+
 maintainer: managementboy / Keptenkurk
 
 BS440google updates weight and fat parameters in Google fit (http://fit.google.com)
 For creating an account and authentication file please see the Wiki for this
 repository.(https://github.com/keptenkurk/BS440/wiki/How-to-use-Google-Fit)
 
-## BS440runalizel
+**BS440runalizel**
+
 maintainer: jovandeginste
 This plugin stores data to local Runalyze database. Runalyze is a performance analyzer for atlethes which goes far beyond the performance trackers like runkeeper and runtastic. 
-
 
 # Thanks to
 * Christopher Peplin - maintainer of Pygatt

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ systemctl enable bs440
 ```
 The logs of the new bs440 service can be shown at all times via ```journalctl -l -f -u bs440```.
 
+If the service runs without any problem if started manually (```systemctl start bs440```) but not
+as a service during startup, check /var/log/syslog for errors. E.g. when activating the mqtt-plugin,
+other services, have to be started first. This can be achieved by setting ```After=multi-user.target```.
+
 # Plugins
 Currenly these plugins are available:
 * BS440mqtt: Send collected data via MQTT to Home Assistant, openHAB, ioBroker for excample

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BS440 - Description
 BS440 is a Python code that listens for information from a Medisana BS410/BS430/BS440/BS444
-or compatible bluetooth bathroom scale. When received via Bluetooth LE , it passes the
+or compatible bluetooth bathroom scale (BSA45 allegedly supported, but manual adjustments needed / not yet correctly implemented in code). When received via Bluetooth LE, it passes the
 information (weight, fat, bone mass, etc) over to all activated plugins for further processing.
 
 Currently supported plugins / data processors:
@@ -47,7 +47,6 @@ This file contains the general parameters for communicating with the scale (Blue
 MAC address) and which plugins to use.
 
 # Automatically start
-
 Copy the right files from the `dist/init` directory.
 
 For generic linux with SystemD support:

--- a/README.md
+++ b/README.md
@@ -46,20 +46,34 @@ Before using this app, rename `BS440.example.ini` to `BS440.ini` and personalize
 This file contains the general parameters for communicating with the scale (Bluetooth LE
 MAC address) and which plugins to use.
 
-# Automatically start
-Copy the right files from the `dist/init` directory.
+# Run the script at startup
+For the script to start automatically at system startup (to monitor the scale all the time)
+the script has to be started as a service.
 
-For generic linux with SystemD support:
+Open the service-file `bs440.service` located under `<...>/BS440-HA-AD/dist/init/linux-systemd/bs440.service`
+and edit/verify the `WorkingDirectory` (the absolute path where the script's files are stored), the
+python directory (usually `/usr/bin/python`) as well as the name of the script (default `BS440.py`).
 
+Copy the service-file (for generic linux with SystemD support) from
+`<...>/BS440-HA-AD/dist/init/linux-systemd/bs440.service` to `/etc/systemd/system`:
 ```bash
-cp dist/init/linux-systemd/bs440.service /etc/systemd/system/
-systemctl daemon-reload   # tell SystemD to detect new service files
-systemctl start bs440     # start the service now
-systemctl enable bs440    # start the service at boot
-journalctl -l -f -u bs440 # show + tail the logs of bs440
+cp <...>/BS440-HA-AD/dist/init/linux-systemd/bs440.service /etc/systemd/system/
 ```
 
-Attention: the systemd service file assumes you copied the contents of this repo to `/opt/BS440`
+Tell SystemD to detect new service files:
+```bash
+systemctl daemon-reload 
+```
+
+Start the service now:
+```bash
+systemctl start bs440
+```
+Set the service to start at boot:
+```bash
+systemctl enable bs440
+```
+The logs of the new bs440 service can be shown at all times via ```journalctl -l -f -u bs440```.
 
 # Plugins
 Currenly these plugins are available:


### PR DESCRIPTION
1. Improved comments to BS440.py.
2. Bug around `SafeConfigParser` is fixed. With `SafeConfigParser` (in current version) the following error is thrown:

```
/home/pi/BS440-HA-AD/BS440_commented.py:286: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  config = SafeConfigParser()
```
ConfigParser is used instead.
3. Division by zero (in case user is not identified) fixed
4. Error message around log.warn fixed
```
/home/pi/BS440-HA-AD/BS440_commented.py:376: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
  log.warn('Error getting handles')
```
5. Improved section "Run the script at startup"-section in README.md